### PR TITLE
Check container args for storage=secret

### DIFF
--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -241,8 +241,8 @@ func GetTillerStorage(tillerNamespace string) string {
 			storage = "secrets"
 		}
 	}
-	for _, c := range container.Args {
-		if strings.Contains(c, "storage=secret") {
+	for _, a := range container.Args {
+		if strings.Contains(a, "storage=secret") {
 			storage = "secrets"
 		}
 	}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -235,12 +235,13 @@ func GetTillerStorage(tillerNamespace string) string {
 	}
 
 	storage := "configmaps"
-	for _, c := range pods.Items[0].Spec.Containers[0].Command {
+	container := pods.Items[0].Spec.Containers[0]
+	for _, c := range container.Command {
 		if strings.Contains(c, "secret") {
 			storage = "secrets"
 		}
 	}
-	for _, c := range pods.Items[0].Spec.Containers[0].Args {
+	for _, c := range container.Args {
 		if strings.Contains(c, "storage=secret") {
 			storage = "secrets"
 		}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -240,6 +240,11 @@ func GetTillerStorage(tillerNamespace string) string {
 			storage = "secrets"
 		}
 	}
+	for _, c := range pods.Items[0].Spec.Containers[0].Args {
+		if strings.Contains(c, "storage=secret") {
+			storage = "secrets"
+		}
+	}
 
 	return storage
 }


### PR DESCRIPTION
Fixes issue https://github.com/maorfr/helm-plugin-utils/issues/10  (CC: https://github.com/helm/helm-2to3/issues/112 )

Checks the container arguments for "storage=secret" so that Tiller pods configured to use secrets instead of configmaps are detected.